### PR TITLE
IValidator, ValidationEscrow, OnchainCheckValidator, OptimisticMediat…

### DIFF
--- a/src/interfaces/IValidator.sol
+++ b/src/interfaces/IValidator.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IValidator {
+    function validate(bytes32 dataHash, bytes memory demand) external;
+}

--- a/src/interfaces/IValidator.sol
+++ b/src/interfaces/IValidator.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
-
-interface IValidator {
-    function validate(bytes32 dataHash, bytes memory demand) external;
-}

--- a/src/peripheral/OnchainCheckValidator.sol
+++ b/src/peripheral/OnchainCheckValidator.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../interfaces/IValidationRegistry.sol";
+import "../interfaces/IIdentityRegistry.sol";
+import "../interfaces/IValidator.sol";
+
+contract OnchainCheckValidator is IValidator {
+    // DemandData could be anything. in this example, we check that keccak256(data) == dataHash
+    struct DemandData {
+        bytes data;
+    }
+
+    IIdentityRegistry public immutable identityRegistry;
+    IValidationRegistry public immutable validationRegistry;
+    uint256 public immutable validatorAgentId;
+
+    uint256 private constant REGISTRATION_FEE = 0.005 ether;
+
+    constructor(
+        address _identityRegistry,
+        address _validationRegistry,
+        string memory _agentDomain
+    ) payable {
+        require(msg.value >= REGISTRATION_FEE, "Insufficient registration fee");
+
+        identityRegistry = IIdentityRegistry(_identityRegistry);
+        validationRegistry = IValidationRegistry(_validationRegistry);
+
+        // Self-register as validator agent
+        validatorAgentId = identityRegistry.newAgent{value: REGISTRATION_FEE}(
+            _agentDomain,
+            address(this)
+        );
+
+        // Refund excess ETH if any
+        if (msg.value > REGISTRATION_FEE) {
+            (bool success, ) = msg.sender.call{
+                value: msg.value - REGISTRATION_FEE
+            }("");
+            require(success, "Refund failed");
+        }
+    }
+
+    function _onchainCheck(
+        bytes32 dataHash,
+        DemandData memory demand
+    ) internal pure returns (uint8) {
+        // this could represent any on-chain computation on (demand, fulfillment dataHash)
+        // in this example, we just check that keccak256(demand.data) == dataHash
+        if (keccak256(demand.data) != dataHash) {
+            return 0;
+        }
+        return 100;
+    }
+
+    function validate(bytes32 dataHash, bytes memory demand) external {
+        DemandData memory demandData = abi.decode(demand, (DemandData));
+
+        validationRegistry.validationResponse(
+            dataHash,
+            _onchainCheck(dataHash, demandData)
+        );
+    }
+}

--- a/src/peripheral/OptimisticMediationValidator.sol
+++ b/src/peripheral/OptimisticMediationValidator.sol
@@ -8,6 +8,7 @@ contract OptimisticMediationValidator {
     struct DemandData {
         address mediator;
         uint256 mediationDeadline;
+        bytes additionalData; // Extra field for arbitrary data
     }
 
     enum MediationResponse {
@@ -21,7 +22,7 @@ contract OptimisticMediationValidator {
     event MediationRequested(
         address mediator,
         uint256 mediationDeadline,
-        bytes demand,
+        bytes additionalData, // Emit the additional data instead of full demand
         bytes fulfillment
     );
 
@@ -62,15 +63,13 @@ contract OptimisticMediationValidator {
     }
 
     function requestMediation(
-        bytes memory demand,
-        bytes memory fulfillment,
-        address mediator,
-        uint256 mediationDeadline
+        DemandData memory demand,
+        bytes memory fulfillment
     ) external {
         emit MediationRequested(
-            mediator,
-            mediationDeadline,
-            demand,
+            demand.mediator,
+            demand.mediationDeadline,
+            demand.additionalData,
             fulfillment
         );
     }

--- a/src/peripheral/OptimisticMediationValidator.sol
+++ b/src/peripheral/OptimisticMediationValidator.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../interfaces/IValidationRegistry.sol";
+import "../interfaces/IIdentityRegistry.sol";
+import "../interfaces/IValidator.sol";
+
+contract OptimisticMediationValidator is IValidator {
+    struct DemandData {
+        address mediator;
+        uint256 mediationDeadline;
+    }
+
+    enum MediationReponse {
+        NONE,
+        ACCEPTED,
+        REJECTED
+    }
+
+    error AwaitingMediation();
+
+    event MediationRequested(
+        bytes32 dataHash,
+        address mediator,
+        uint256 mediationDeadline
+    );
+
+    mapping(address => mapping(bytes32 => MediationReponse)) private _responses;
+
+    function mediate(bytes32 dataHash, MediationReponse response) external {
+        _responses[msg.sender][dataHash] = response;
+    }
+
+    mapping(address => mapping(bytes32 => uint8)) private _mediations;
+
+    IIdentityRegistry public immutable identityRegistry;
+    IValidationRegistry public immutable validationRegistry;
+    uint256 public immutable validatorAgentId;
+
+    uint256 private constant REGISTRATION_FEE = 0.005 ether;
+
+    constructor(
+        address _identityRegistry,
+        address _validationRegistry,
+        string memory _agentDomain
+    ) payable {
+        require(msg.value >= REGISTRATION_FEE, "Insufficient registration fee");
+
+        identityRegistry = IIdentityRegistry(_identityRegistry);
+        validationRegistry = IValidationRegistry(_validationRegistry);
+
+        // Self-register as validator agent
+        validatorAgentId = identityRegistry.newAgent{value: REGISTRATION_FEE}(
+            _agentDomain,
+            address(this)
+        );
+
+        // Refund excess ETH if any
+        if (msg.value > REGISTRATION_FEE) {
+            (bool success, ) = msg.sender.call{
+                value: msg.value - REGISTRATION_FEE
+            }("");
+            require(success, "Refund failed");
+        }
+    }
+
+    function requestMediation(
+        bytes32 dataHash,
+        address mediator,
+        uint256 mediationDeadline
+    ) external {
+        emit MediationRequested(dataHash, mediator, mediationDeadline);
+    }
+
+    function validate(bytes32 dataHash, bytes memory demand) external {
+        DemandData memory demandData = abi.decode(demand, (DemandData));
+
+        MediationReponse response = _responses[demandData.mediator][dataHash];
+
+        if (response == MediationReponse.ACCEPTED) {
+            validationRegistry.validationResponse(dataHash, 100);
+            return;
+        }
+
+        if (response == MediationReponse.REJECTED) {
+            validationRegistry.validationResponse(dataHash, 0);
+            return;
+        }
+
+        // If no response (NONE) and past deadline, optimistic acceptance
+        if (
+            response == MediationReponse.NONE &&
+            block.timestamp > demandData.mediationDeadline
+        ) {
+            // optimistic mediation: accept by default
+            validationRegistry.validationResponse(dataHash, 100);
+            return;
+        }
+
+        // No response and not past deadline - do not validate yet
+        revert AwaitingMediation();
+    }
+}

--- a/src/peripheral/ValidationEscrow.sol
+++ b/src/peripheral/ValidationEscrow.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../interfaces/IValidationRegistry.sol";
+import "../interfaces/IIdentityRegistry.sol";
+import "../interfaces/IValidator.sol";
+
+contract ValidationEscrow {
+    struct Escrow {
+        address escrower;
+        uint256 agentValidatorId;
+        uint256 agentServerId;
+        uint256 amount;
+        uint256 expirationTime;
+        uint8 minValidation;
+        address validator;
+        bytes demand;
+    }
+
+    event EscrowDepositEvent(
+        uint256 indexed escrowId,
+        address indexed escrower
+    );
+    event EscrowClaimEvent(uint256 indexed escrowId, address indexed claimant);
+    event EscrowReclaimEvent(
+        uint256 indexed escrowId,
+        address indexed escrower
+    );
+
+    error AgentNotFound();
+    error InvalidEscrow();
+    error InvalidEscrowParameters();
+    error InvalidValidation();
+    error UnauthorizedClaim();
+    error TransferFailed();
+
+    IIdentityRegistry public immutable identityRegistry;
+    IValidationRegistry public immutable validationRegistry;
+
+    uint256 private _escrowCounter;
+    mapping(uint256 => Escrow) private _escrows;
+    mapping(uint256 => bool) private _claimed;
+
+    constructor(address _identityRegistry, address _validationRegistry) {
+        identityRegistry = IIdentityRegistry(_identityRegistry);
+        validationRegistry = IValidationRegistry(_validationRegistry);
+    }
+
+    function depositEscrow(
+        uint256 agentValidatorId,
+        uint256 agentServerId,
+        uint256 amount,
+        uint256 expirationTime,
+        uint8 minValidation,
+        address validator,
+        bytes memory demand
+    ) external payable returns (uint256 escrowId_) {
+        if (!identityRegistry.agentExists(agentValidatorId)) {
+            revert AgentNotFound();
+        }
+        if (!identityRegistry.agentExists(agentServerId)) {
+            revert AgentNotFound();
+        }
+        if (amount == 0) {
+            revert InvalidEscrowParameters();
+        }
+        if (expirationTime < block.timestamp) {
+            revert InvalidEscrowParameters();
+        }
+
+        if (msg.value != amount) {
+            revert TransferFailed();
+        }
+
+        escrowId_ = _escrowCounter++;
+        _escrows[escrowId_] = Escrow(
+            msg.sender,
+            agentValidatorId,
+            agentServerId,
+            amount,
+            expirationTime,
+            minValidation,
+            validator,
+            demand
+        );
+
+        emit EscrowDepositEvent(escrowId_, msg.sender);
+    }
+
+    function claimEscrow(uint256 escrowId, bytes32 dataHash) external {
+        Escrow storage escrow = _escrows[escrowId];
+        if (escrow.amount == 0) {
+            revert InvalidEscrow();
+        }
+        if (escrow.expirationTime < block.timestamp) {
+            revert InvalidEscrow();
+        }
+        if (_claimed[escrowId]) {
+            revert InvalidEscrow();
+        }
+
+        IIdentityRegistry.AgentInfo memory serverAgent = identityRegistry
+            .getAgent(escrow.agentServerId);
+        if (msg.sender != serverAgent.agentAddress) {
+            revert UnauthorizedClaim();
+        }
+
+        IValidator(escrow.validator).validate(dataHash, escrow.demand);
+
+        IValidationRegistry.Request
+            memory validationRequest = validationRegistry.getValidationRequest(
+                dataHash
+            );
+        if (validationRequest.dataHash == 0) {
+            revert InvalidValidation();
+        }
+        if (validationRequest.agentValidatorId != escrow.agentValidatorId) {
+            revert InvalidValidation();
+        }
+        if (validationRequest.agentServerId != escrow.agentServerId) {
+            revert InvalidValidation();
+        }
+
+        (bool hasResponse, uint8 validationResponse) = validationRegistry
+            .getValidationResponse(dataHash);
+        if (!hasResponse) {
+            revert InvalidValidation();
+        }
+        if (validationResponse < escrow.minValidation) {
+            revert InvalidValidation();
+        }
+
+        (bool success, ) = payable(msg.sender).call{value: escrow.amount}("");
+        if (!success) {
+            revert TransferFailed();
+        }
+
+        _claimed[escrowId] = true;
+        emit EscrowClaimEvent(escrowId, msg.sender);
+    }
+
+    function reclaimExpired(uint256 escrowId) external {
+        Escrow storage escrow = _escrows[escrowId];
+        if (escrow.amount == 0) {
+            revert InvalidEscrow();
+        }
+        if (_claimed[escrowId]) {
+            revert InvalidEscrow();
+        }
+        if (msg.sender != escrow.escrower) {
+            revert UnauthorizedClaim();
+        }
+        if (escrow.expirationTime > block.timestamp) {
+            revert UnauthorizedClaim();
+        }
+
+        (bool success, ) = payable(msg.sender).call{value: escrow.amount}("");
+        if (!success) {
+            revert TransferFailed();
+        }
+
+        _claimed[escrowId] = true;
+        emit EscrowReclaimEvent(escrowId, msg.sender);
+    }
+
+    function getEscrow(uint256 escrowId) external view returns (Escrow memory) {
+        return _escrows[escrowId];
+    }
+}

--- a/test/OptimisticMediationExample.t.sol
+++ b/test/OptimisticMediationExample.t.sol
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../src/IdentityRegistry.sol";
+import "../src/ValidationRegistry.sol";
+import "../src/peripheral/ValidationEscrow.sol";
+import "../src/peripheral/OptimisticMediationValidator.sol";
+
+contract OptimisticMediationExample is Test {
+    IdentityRegistry public identityRegistry;
+    ValidationRegistry public validationRegistry;
+    ValidationEscrow public validationEscrow;
+    OptimisticMediationValidator public mediationValidator;
+
+    address public server = address(0x2);
+    address public client = address(0x3);
+    address public mediator = address(0x4);
+
+    uint256 public validatorAgentId;
+    uint256 public serverAgentId;
+
+    uint256 constant REGISTRATION_FEE = 0.005 ether;
+
+    function setUp() public {
+        // Deploy core contracts
+        identityRegistry = new IdentityRegistry();
+        validationRegistry = new ValidationRegistry(address(identityRegistry));
+
+        // Deploy peripheral contracts
+        validationEscrow = new ValidationEscrow(
+            address(identityRegistry),
+            address(validationRegistry)
+        );
+
+        // Deploy OptimisticMediationValidator with registration fee
+        mediationValidator = new OptimisticMediationValidator{
+            value: REGISTRATION_FEE
+        }(
+            address(identityRegistry),
+            address(validationRegistry),
+            "optimistic-validator.example.com"
+        );
+
+        // Get the validator agent ID from the contract
+        validatorAgentId = mediationValidator.validatorAgentId();
+
+        // Fund test accounts
+        vm.deal(server, 1 ether);
+        vm.deal(client, 10 ether);
+        vm.deal(mediator, 1 ether);
+
+        // Register server agent
+        vm.prank(server);
+        serverAgentId = identityRegistry.newAgent{value: REGISTRATION_FEE}(
+            "server.example.com",
+            server
+        );
+    }
+
+    function testOptimisticAcceptanceAfterDeadline() public {
+        // Setup escrow with optimistic mediation
+        uint256 escrowAmount = 1 ether;
+        uint256 expirationTime = block.timestamp + 1 hours;
+        uint8 minValidation = 50;
+
+        // Set mediation deadline to 5 minutes from now
+        uint256 mediationDeadline = block.timestamp + 5 minutes;
+
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator,
+                mediationDeadline: mediationDeadline
+            })
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("service provided successfully");
+
+        // Server requests validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Server requests mediation (emits event for mediator)
+        vm.prank(server);
+        mediationValidator.requestMediation(
+            dataHash,
+            mediator,
+            mediationDeadline
+        );
+
+        // Fast forward past mediation deadline - mediator didn't respond
+        vm.warp(block.timestamp + 6 minutes);
+
+        // Server can now claim - optimistic acceptance kicks in
+        uint256 serverBalanceBefore = server.balance;
+
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        // Verify server received funds
+        uint256 serverBalanceAfter = server.balance;
+        assertEq(serverBalanceAfter - serverBalanceBefore, escrowAmount);
+    }
+
+    function testMediatorAcceptsValidation() public {
+        // Setup escrow
+        uint256 escrowAmount = 1 ether;
+        uint256 expirationTime = block.timestamp + 1 hours;
+        uint8 minValidation = 50;
+        uint256 mediationDeadline = block.timestamp + 30 minutes;
+
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator,
+                mediationDeadline: mediationDeadline
+            })
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("service data");
+
+        // Server requests validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Mediator accepts the validation
+        vm.prank(mediator);
+        mediationValidator.mediate(
+            dataHash,
+            OptimisticMediationValidator.MediationReponse.ACCEPTED
+        );
+
+        // Server can claim immediately after acceptance
+        uint256 serverBalanceBefore = server.balance;
+
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        uint256 serverBalanceAfter = server.balance;
+        assertEq(serverBalanceAfter - serverBalanceBefore, escrowAmount);
+    }
+
+    function testMediatorRejectsValidation() public {
+        // Setup escrow with high minimum validation
+        uint256 escrowAmount = 1 ether;
+        uint256 expirationTime = block.timestamp + 1 hours;
+        uint8 minValidation = 50; // Requires at least 50/100
+        uint256 mediationDeadline = block.timestamp + 30 minutes;
+
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator,
+                mediationDeadline: mediationDeadline
+            })
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("disputed service");
+
+        // Server requests validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Mediator rejects the validation
+        vm.prank(mediator);
+        mediationValidator.mediate(
+            dataHash,
+            OptimisticMediationValidator.MediationReponse.REJECTED
+        );
+
+        // Server cannot claim - validation score is 0
+        vm.prank(server);
+        vm.expectRevert(ValidationEscrow.InvalidValidation.selector);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        // Client can reclaim after expiration
+        vm.warp(block.timestamp + 2 hours);
+
+        uint256 clientBalanceBefore = client.balance;
+
+        vm.prank(client);
+        validationEscrow.reclaimExpired(escrowId);
+
+        uint256 clientBalanceAfter = client.balance;
+        assertEq(clientBalanceAfter - clientBalanceBefore, escrowAmount);
+    }
+
+    function testMultipleMediators() public {
+        // This test shows how different escrows can have different mediators
+        address mediator1 = address(0x100);
+        address mediator2 = address(0x200);
+
+        bytes32 dataHash1 = keccak256("service1");
+        bytes32 dataHash2 = keccak256("service2");
+
+        // First escrow with mediator1
+        bytes memory demand1 = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator1,
+                mediationDeadline: block.timestamp + 10 minutes
+            })
+        );
+
+        vm.prank(client);
+        uint256 escrowId1 = validationEscrow.depositEscrow{value: 0.5 ether}(
+            validatorAgentId,
+            serverAgentId,
+            0.5 ether,
+            block.timestamp + 1 hours,
+            50,
+            address(mediationValidator),
+            demand1
+        );
+
+        // Second escrow with mediator2
+        bytes memory demand2 = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator2,
+                mediationDeadline: block.timestamp + 20 minutes
+            })
+        );
+
+        vm.prank(client);
+        uint256 escrowId2 = validationEscrow.depositEscrow{value: 0.5 ether}(
+            validatorAgentId,
+            serverAgentId,
+            0.5 ether,
+            block.timestamp + 1 hours,
+            50,
+            address(mediationValidator),
+            demand2
+        );
+
+        // Request validations
+        vm.startPrank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash1
+        );
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash2
+        );
+        vm.stopPrank();
+
+        // Mediator1 accepts, Mediator2 rejects
+        vm.prank(mediator1);
+        mediationValidator.mediate(
+            dataHash1,
+            OptimisticMediationValidator.MediationReponse.ACCEPTED
+        );
+
+        vm.prank(mediator2);
+        mediationValidator.mediate(
+            dataHash2,
+            OptimisticMediationValidator.MediationReponse.REJECTED
+        );
+
+        // Server can claim escrow1 but not escrow2
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId1, dataHash1); // Success
+
+        vm.prank(server);
+        vm.expectRevert(ValidationEscrow.InvalidValidation.selector);
+        validationEscrow.claimEscrow(escrowId2, dataHash2); // Fails
+    }
+
+    function testValidatorSelfRegistration() public {
+        // Verify that the OptimisticMediationValidator successfully registered itself
+        assertTrue(identityRegistry.agentExists(validatorAgentId));
+
+        // Get the agent info to verify registration details
+        IIdentityRegistry.AgentInfo memory agentInfo = identityRegistry
+            .getAgent(validatorAgentId);
+
+        // Verify the agent details
+        assertEq(agentInfo.agentId, validatorAgentId);
+        assertEq(agentInfo.agentDomain, "optimistic-validator.example.com");
+        assertEq(agentInfo.agentAddress, address(mediationValidator));
+
+        // Verify we can resolve by domain
+        IIdentityRegistry.AgentInfo memory byDomain = identityRegistry
+            .resolveByDomain("optimistic-validator.example.com");
+        assertEq(byDomain.agentAddress, address(mediationValidator));
+
+        // Verify we can resolve by address
+        IIdentityRegistry.AgentInfo memory byAddress = identityRegistry
+            .resolveByAddress(address(mediationValidator));
+        assertEq(byAddress.agentDomain, "optimistic-validator.example.com");
+
+        // Deploy another validator with different domain
+        OptimisticMediationValidator anotherValidator = new OptimisticMediationValidator{
+                value: REGISTRATION_FEE
+            }(
+                address(identityRegistry),
+                address(validationRegistry),
+                "another-optimistic.example.com"
+            );
+
+        // Verify it gets a different agent ID
+        assertTrue(anotherValidator.validatorAgentId() != validatorAgentId);
+        assertTrue(
+            identityRegistry.agentExists(anotherValidator.validatorAgentId())
+        );
+    }
+
+    function testWrongMediatorCannotInfluence() public {
+        // Test that only the designated mediator can influence validation
+        address wrongMediator = address(0x999);
+
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator, // Correct mediator
+                mediationDeadline: block.timestamp + 30 minutes
+            })
+        );
+
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: 1 ether}(
+            validatorAgentId,
+            serverAgentId,
+            1 ether,
+            block.timestamp + 1 hours,
+            50,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("some service");
+
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Wrong mediator tries to accept
+        vm.prank(wrongMediator);
+        mediationValidator.mediate(
+            dataHash,
+            OptimisticMediationValidator.MediationReponse.ACCEPTED
+        );
+
+        // With NONE enum value, uninitialized responses are properly handled.
+        // Without the correct mediator's response, validation should fail
+        // before the deadline.
+
+        // Before deadline, no valid response from correct mediator
+        vm.warp(block.timestamp + 10 minutes);
+
+        // Server tries to claim - should fail because correct mediator hasn't responded
+        vm.prank(server);
+        vm.expectRevert(
+            OptimisticMediationValidator.AwaitingMediation.selector
+        );
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        // But after deadline, optimistic acceptance works
+        vm.warp(block.timestamp + 31 minutes);
+
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, dataHash); // Now succeeds via optimistic acceptance
+    }
+
+    function testNoneResponseBehavior() public {
+        // This test explicitly verifies NONE enum behavior
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator,
+                mediationDeadline: block.timestamp + 30 minutes
+            })
+        );
+
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: 1 ether}(
+            validatorAgentId,
+            serverAgentId,
+            1 ether,
+            block.timestamp + 2 hours,
+            50,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("test data");
+
+        // Request validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Before deadline, with NONE response (default), validation should revert
+        vm.prank(server);
+        vm.expectRevert(
+            OptimisticMediationValidator.AwaitingMediation.selector
+        );
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        // Fast forward past deadline
+        vm.warp(block.timestamp + 31 minutes);
+
+        // Now with NONE response but past deadline, optimistic acceptance occurs
+        uint256 serverBalanceBefore = server.balance;
+
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        uint256 serverBalanceAfter = server.balance;
+        assertEq(serverBalanceAfter - serverBalanceBefore, 1 ether);
+    }
+
+    function testExplicitMediatorResponseOverridesOptimistic() public {
+        // Test that explicit mediator response before deadline takes precedence
+        bytes memory demand = abi.encode(
+            OptimisticMediationValidator.DemandData({
+                mediator: mediator,
+                mediationDeadline: block.timestamp + 30 minutes
+            })
+        );
+
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: 1 ether}(
+            validatorAgentId,
+            serverAgentId,
+            1 ether,
+            block.timestamp + 2 hours,
+            50,
+            address(mediationValidator),
+            demand
+        );
+
+        bytes32 dataHash = keccak256("service data");
+
+        // Request validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Mediator explicitly rejects before deadline
+        vm.prank(mediator);
+        mediationValidator.mediate(
+            dataHash,
+            OptimisticMediationValidator.MediationReponse.REJECTED
+        );
+
+        // Even after deadline, rejection stands (not optimistic acceptance)
+        vm.warp(block.timestamp + 31 minutes);
+
+        vm.prank(server);
+        vm.expectRevert(ValidationEscrow.InvalidValidation.selector);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+    }
+}

--- a/test/ValidationEscrowExample.t.sol
+++ b/test/ValidationEscrowExample.t.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../src/IdentityRegistry.sol";
+import "../src/ValidationRegistry.sol";
+import "../src/peripheral/ValidationEscrow.sol";
+import "../src/peripheral/OnchainCheckValidator.sol";
+
+contract ValidationEscrowExample is Test {
+    IdentityRegistry public identityRegistry;
+    ValidationRegistry public validationRegistry;
+    ValidationEscrow public validationEscrow;
+    OnchainCheckValidator public onchainCheckValidator;
+
+    address public server = address(0x2);
+    address public client = address(0x3);
+
+    uint256 public validatorAgentId;
+    uint256 public serverAgentId;
+
+    uint256 constant REGISTRATION_FEE = 0.005 ether;
+
+    function setUp() public {
+        // Deploy core contracts
+        identityRegistry = new IdentityRegistry();
+        validationRegistry = new ValidationRegistry(address(identityRegistry));
+
+        // Deploy peripheral contracts
+        validationEscrow = new ValidationEscrow(
+            address(identityRegistry),
+            address(validationRegistry)
+        );
+
+        // Deploy OnchainCheckValidator with registration fee
+        onchainCheckValidator = new OnchainCheckValidator{
+            value: REGISTRATION_FEE
+        }(
+            address(identityRegistry),
+            address(validationRegistry),
+            "validator.example.com"
+        );
+
+        // Get the validator agent ID from the contract
+        validatorAgentId = onchainCheckValidator.validatorAgentId();
+
+        // Fund test accounts
+        vm.deal(server, 1 ether);
+        vm.deal(client, 10 ether);
+
+        // Register server agent
+        vm.prank(server);
+        serverAgentId = identityRegistry.newAgent{value: REGISTRATION_FEE}(
+            "server.example.com",
+            server
+        );
+    }
+
+    function testSuccessfulEscrowClaimFlow() public {
+        // 1. Client deposits escrow with specific validation requirements
+        uint256 escrowAmount = 1 ether;
+        uint256 expirationTime = block.timestamp + 1 hours;
+        uint8 minValidation = 50; // Minimum validation score of 50/100
+
+        // Prepare the demand data - this is what the server must provide
+        bytes memory expectedData = "Hello, World!";
+        bytes32 expectedDataHash = keccak256(expectedData);
+
+        // Encode the demand for OnchainCheckValidator
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: expectedData})
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Verify escrow was created
+        ValidationEscrow.Escrow memory escrow = validationEscrow.getEscrow(
+            escrowId
+        );
+        assertEq(escrow.escrower, client);
+        assertEq(escrow.amount, escrowAmount);
+        assertEq(escrow.minValidation, minValidation);
+
+        // 2. Server requests validation for the data they want to submit
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            expectedDataHash
+        );
+
+        // 3. Server claims the escrow by providing the correct data hash
+        uint256 serverBalanceBefore = server.balance;
+
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, expectedDataHash);
+
+        // Verify server received the funds
+        uint256 serverBalanceAfter = server.balance;
+        assertEq(serverBalanceAfter - serverBalanceBefore, escrowAmount);
+    }
+
+    function testValidationFailureDoesNotReleaseFunds() public {
+        // Setup escrow with high minimum validation requirement
+        uint256 escrowAmount = 0.5 ether;
+        uint256 expirationTime = block.timestamp + 1 hours;
+        uint8 minValidation = 100; // Requires perfect validation score
+
+        // Prepare demand data
+        bytes memory expectedData = "Correct Data";
+        bytes memory wrongData = "Wrong Data";
+        bytes32 wrongDataHash = keccak256(wrongData);
+
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: expectedData})
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Server requests validation with wrong data
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            wrongDataHash
+        );
+
+        // Server tries to claim with wrong data hash - should fail
+        vm.prank(server);
+        vm.expectRevert(ValidationEscrow.InvalidValidation.selector);
+        validationEscrow.claimEscrow(escrowId, wrongDataHash);
+    }
+
+    function testClientCanReclaimAfterExpiration() public {
+        // Setup escrow with short expiration
+        uint256 escrowAmount = 0.5 ether;
+        uint256 expirationTime = block.timestamp + 1 minutes;
+        uint8 minValidation = 50;
+
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: "Some Data"})
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Fast forward past expiration
+        vm.warp(block.timestamp + 2 minutes);
+
+        // Client reclaims expired escrow
+        uint256 clientBalanceBefore = client.balance;
+
+        vm.prank(client);
+        validationEscrow.reclaimExpired(escrowId);
+
+        uint256 clientBalanceAfter = client.balance;
+        assertEq(clientBalanceAfter - clientBalanceBefore, escrowAmount);
+    }
+
+    function testComplexDemandValidation() public {
+        // This test shows how OnchainCheckValidator can validate complex data
+        uint256 escrowAmount = 2 ether;
+        uint256 expirationTime = block.timestamp + 24 hours;
+        uint8 minValidation = 75;
+
+        // Create complex data structure
+        bytes memory complexData = abi.encode(
+            uint256(42),
+            "Complex validation test",
+            address(this)
+        );
+        bytes32 dataHash = keccak256(complexData);
+
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: complexData})
+        );
+
+        // Client deposits escrow
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            expirationTime,
+            minValidation,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Server requests validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Server claims with correct complex data
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+
+        // Verify claim was successful by checking the escrow can't be reclaimed
+        vm.prank(client);
+        vm.expectRevert(ValidationEscrow.InvalidEscrow.selector);
+        validationEscrow.reclaimExpired(escrowId);
+    }
+
+    function testUnauthorizedClaimAttempt() public {
+        // Setup escrow
+        uint256 escrowAmount = 1 ether;
+        bytes memory data = "Test Data";
+        bytes32 dataHash = keccak256(data);
+
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: data})
+        );
+
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            block.timestamp + 1 hours,
+            50,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Request validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            dataHash
+        );
+
+        // Random address tries to claim - should fail
+        address randomUser = address(0x999);
+        vm.prank(randomUser);
+        vm.expectRevert(ValidationEscrow.UnauthorizedClaim.selector);
+        validationEscrow.claimEscrow(escrowId, dataHash);
+    }
+
+    function testPartialValidationScore() public {
+        // This test shows behavior with different validation scores
+        uint256 escrowAmount = 1 ether;
+        uint8 minValidation = 60; // Requires at least 60/100
+
+        bytes memory correctData = "Correct";
+        bytes32 correctHash = keccak256(correctData);
+
+        bytes memory demand = abi.encode(
+            OnchainCheckValidator.DemandData({data: correctData})
+        );
+
+        vm.prank(client);
+        uint256 escrowId = validationEscrow.depositEscrow{value: escrowAmount}(
+            validatorAgentId,
+            serverAgentId,
+            escrowAmount,
+            block.timestamp + 1 hours,
+            minValidation,
+            address(onchainCheckValidator),
+            demand
+        );
+
+        // Request validation
+        vm.prank(server);
+        validationRegistry.validationRequest(
+            validatorAgentId,
+            serverAgentId,
+            correctHash
+        );
+
+        // OnchainCheckValidator returns 100 for exact match, 0 for mismatch
+        // In this case, we have exact match so score is 100, which exceeds minimum of 60
+        vm.prank(server);
+        validationEscrow.claimEscrow(escrowId, correctHash);
+
+        // Verify successful claim
+        assertEq(server.balance, 2 ether - REGISTRATION_FEE); // Initial 1 ETH - 0.005 ETH fee + 1 ETH claimed = 1.995 ETH
+    }
+
+    function testValidatorSelfRegistration() public {
+        // Verify that the OnchainCheckValidator successfully registered itself
+        assertTrue(identityRegistry.agentExists(validatorAgentId));
+
+        // Get the agent info to verify registration details
+        IIdentityRegistry.AgentInfo memory agentInfo = identityRegistry
+            .getAgent(validatorAgentId);
+
+        // Verify the agent details
+        assertEq(agentInfo.agentId, validatorAgentId);
+        assertEq(agentInfo.agentDomain, "validator.example.com");
+        assertEq(agentInfo.agentAddress, address(onchainCheckValidator));
+
+        // Verify we can resolve by domain
+        IIdentityRegistry.AgentInfo memory byDomain = identityRegistry
+            .resolveByDomain("validator.example.com");
+        assertEq(byDomain.agentAddress, address(onchainCheckValidator));
+
+        // Verify we can resolve by address
+        IIdentityRegistry.AgentInfo memory byAddress = identityRegistry
+            .resolveByAddress(address(onchainCheckValidator));
+        assertEq(byAddress.agentDomain, "validator.example.com");
+
+        // Verify the validator agent ID is correctly stored in the contract
+        assertEq(onchainCheckValidator.validatorAgentId(), validatorAgentId);
+
+        // Deploy another validator with different domain to verify unique registration
+        OnchainCheckValidator anotherValidator = new OnchainCheckValidator{
+            value: REGISTRATION_FEE
+        }(
+            address(identityRegistry),
+            address(validationRegistry),
+            "another-validator.example.com"
+        );
+
+        // Verify it gets a different agent ID
+        assertTrue(anotherValidator.validatorAgentId() != validatorAgentId);
+        assertTrue(
+            identityRegistry.agentExists(anotherValidator.validatorAgentId())
+        );
+    }
+}


### PR DESCRIPTION
I added an example demonstrating on-chain escrow in combination with the validation registry from the reference implementation, along with two example validators:
- OnchainCheckValidator, demonstrating a synchronous validation that can be completed in one tx
- OptimisticMediation, demonstrating an asynchronous validation process over multiple txs

I think adding a taskId field to validations, by which agent tasks can be referenced before they concretely exist (as a dataHash) would enable these escrow processes to work without the extra IValidator interface, and remove the dependency of the validationResponse call site on the escrow contract (since there must be an association between an escrow, its demand data, and its validation response, which requires direct access or a reference to the escrow data at the validationResponse call site unless escrows can reference a not-yet-existing task, and validation contracts can share the same reference in demands).

[Associated discussion on Ethereum Magicians](https://ethereum-magicians.org/t/erc-8004-trustless-agents/25098/22?u=mlegls)